### PR TITLE
Modified spinner display logic on post-create page

### DIFF
--- a/mean/mean-project/src/app/posts/post-create/post-create.component.ts
+++ b/mean/mean-project/src/app/posts/post-create/post-create.component.ts
@@ -1,6 +1,8 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, ParamMap } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { AuthService } from 'src/app/auth/auth.service';
 import { Post } from 'src/app/interfaces/post.interface';
 
 import { PostsService } from 'src/app/posts/posts.service';
@@ -11,22 +13,30 @@ import { mimeType } from './mime-type.validator';
   templateUrl: './post-create.component.html',
   styleUrls: ['./post-create.component.css'],
 })
-export class PostCreateComponent implements OnInit {
+export class PostCreateComponent implements OnInit, OnDestroy {
   enteredTitle = '';
   enteredContent = '';
   form!: FormGroup;
-  private mode = 'create';
-  private postId: any;
   post: Post = {} as Post;
   isLoading = false;
   imagePreview: string = '';
+  private mode = 'create';
+  private postId: any;
+  private authStatusSub?: Subscription;
 
   constructor(
     private postService: PostsService,
-    public route: ActivatedRoute
+    public route: ActivatedRoute,
+    private authService: AuthService
   ) {}
 
   ngOnInit() {
+    this.authStatusSub = this.authService
+      .getAuthStatusListener()
+      .subscribe((authStatus) => {
+        this.isLoading = false;
+      });
+
     this.form = new FormGroup({
       title: new FormControl(null, {
         validators: [Validators.required, Validators.minLength(3)],
@@ -98,5 +108,9 @@ export class PostCreateComponent implements OnInit {
       );
     }
     this.form.reset();
+  }
+
+  ngOnDestroy() {
+    this.authStatusSub?.unsubscribe();
   }
 }


### PR DESCRIPTION
When a user who is not authenticated click on the save post button, the spinner will stop after the error message dialog displayed.